### PR TITLE
scrollbarWidth calculation fixes for ie

### DIFF
--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -691,10 +691,10 @@
         var scrollbarWidth = 0;
 
         if (!scrollbarWidth) {
-          if (/msie/.test(navigator.userAgent.toLowerCase())) {
-            var $textarea1 = $('<textarea cols="10" rows="2"></textarea>')
+          if (/msie|trident/.test(navigator.userAgent.toLowerCase())) {
+            var $textarea1 = $('<textarea cols="10" rows="2" style="width:auto;"></textarea>')
                   .css({ position: 'absolute', top: -1000, left: -1000 }).appendTo('body'),
-                $textarea2 = $('<textarea cols="10" rows="2" style="overflow: hidden;"></textarea>')
+                $textarea2 = $('<textarea cols="10" rows="2" style="width:auto;overflow: hidden;"></textarea>')
                   .css({ position: 'absolute', top: -1000, left: -1000 }).appendTo('body');
 
             scrollbarWidth = $textarea1.width() - $textarea2.width() + 2; // + 2 for border offset


### PR DESCRIPTION
- IE 11 doesn't use msie in user agent string
- Set the texarea width explicitly, so it doesn't get affected by
  unrelated css styles.
