### PR TITLE
Fixed Typo in demo: fixedColumns with s at the end

### DIFF
--- a/demo/test.html
+++ b/demo/test.html
@@ -993,7 +993,7 @@ $('#myTable04').fixedHeaderTable({
 	altClass: 'odd',
 	footer: true,
 	cloneHeadToFoot: true,
-	fixedColumn: 3,
+	fixedColumns: 3,
 });
         			</code>
         		</pre>


### PR DESCRIPTION
just a small typo in the demo
